### PR TITLE
Enhance frontend styling

### DIFF
--- a/next-app/src/app/layout.tsx
+++ b/next-app/src/app/layout.tsx
@@ -27,7 +27,7 @@ const RootLayout = ({ children }: PropsWithChildren) => {
     <html lang="en" suppressHydrationWarning>
       <body
         className={cn(
-          "flex justify-center min-h-screen bg-background font-sans antialiased",
+          "flex justify-center min-h-screen bg-gradient-to-br from-slate-50 to-teal-100 dark:from-gray-900 dark:to-gray-800 font-sans antialiased",
           fontSans.variable
         )}
       >

--- a/next-app/src/app/page.tsx
+++ b/next-app/src/app/page.tsx
@@ -1,11 +1,15 @@
 import { MessageBoard } from "@/components/MessageBoard";
 import { CreateMessage } from "@/components/CreateMessage";
+import { Hero } from "@/components/Hero";
 
 export default function HomePage() {
   return (
-    <div className="space-y-4">
-      <MessageBoard />
-      <CreateMessage />
+    <div className="space-y-10">
+      <Hero />
+      <div className="grid gap-6 md:grid-cols-2 md:items-start">
+        <MessageBoard />
+        <CreateMessage />
+      </div>
     </div>
   );
 }

--- a/next-app/src/components/CreateMessage.tsx
+++ b/next-app/src/components/CreateMessage.tsx
@@ -106,7 +106,7 @@ export function CreateMessage() {
   };
 
   return (
-    <Card>
+    <Card className="shadow-xl">
       <CardHeader>
         <CardTitle>Create a new message</CardTitle>
         <CardDescription>

--- a/next-app/src/components/Hero.tsx
+++ b/next-app/src/components/Hero.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export const Hero = () => {
+  return (
+    <section className="text-center py-10 space-y-4">
+      <h2 className="text-4xl font-extrabold bg-gradient-to-r from-orange-400 via-pink-500 to-purple-600 bg-clip-text text-transparent">
+        Aptos Full Stack Demo
+      </h2>
+      <p className="text-muted-foreground">
+        Explore messages and interact with the blockchain.
+      </p>
+    </section>
+  );
+};

--- a/next-app/src/components/MessageBoard.tsx
+++ b/next-app/src/components/MessageBoard.tsx
@@ -4,7 +4,7 @@ import { columns } from "@/components/message-board/columns";
 
 export const MessageBoard = async () => {
   return (
-    <Card>
+    <Card className="shadow-xl">
       <CardHeader>
         <CardTitle>Message board</CardTitle>
       </CardHeader>

--- a/next-app/src/components/RootHeader.tsx
+++ b/next-app/src/components/RootHeader.tsx
@@ -5,7 +5,7 @@ export const RootHeader = () => {
   return (
     <div className="flex justify-between items-center gap-6 pb-5">
       <div className="flex flex-col gap-2 md:gap-3">
-        <h1 className="text-xl font-semibold tracking-tight">
+        <h1 className="text-xl font-semibold tracking-tight bg-gradient-to-r from-orange-400 via-pink-500 to-purple-600 bg-clip-text text-transparent">
           <a href="/">Aptos Full Stack Demo App</a>
         </h1>
       </div>


### PR DESCRIPTION
## Summary
- add new Hero component with gradient heading
- arrange homepage in a grid with hero section
- tweak header title with gradient text
- give body a soft gradient background
- apply extra shadow to MessageBoard and CreateMessage cards

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687ae370776c8328982cdab7bc7643ef